### PR TITLE
Add more sites that abuse the slash key

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,14 @@ gets the slash key (same problem as with the JS overlay).
 Sample sites that abuse the slash key:
 --------------------------------------
 
-* [YouTube](https://www.youtube.com/watch?v=TllPrdbZ-VI)
-* [Google Groups](https://groups.google.com/forum/#!msg/vim_use/r3TdW9G9ms4/s-Jr3BpcnvUJ)
+* [Bitbucket](https://bitbucket.org/)
+* [Django documentation](https://docs.djangoproject.com/)
+* Anything by [Google](https://www.google.com/)
+    * [Android Studio docs](http://tools.android.com/)
+    * [Android docs](https://developer.android.com/reference/packages.html), whose slash-breaker
+      is buggy, so it only sometimes hijacks the slash key
+    * [YouTube](https://www.youtube.com/watch?v=TllPrdbZ-VI)
+    * [Google Groups](https://groups.google.com/forum/#!msg/vim_use/r3TdW9G9ms4/s-Jr3BpcnvUJ)
 
 See also:
 ---------


### PR DESCRIPTION
Incidentally, this [Greasemonkey script](https://gist.github.com/julfers/85fdae998ad855de17d2326e1c141cac) is what I actually use to preserve my slash key. Seems to work fine. Perhaps thanks to new Firefox versions?